### PR TITLE
Allow support for mix releases in 1.9

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,36 +2,37 @@ defmodule RemoteIp.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :remote_ip,
-     version: "0.1.4",
-     elixir: "~> 1.3",
-     package: package(),
-     description: description(),
-     deps: deps(),
-     docs: [source_url: "https://github.com/ajvondrak/remote_ip"]]
-  end
-
-  def application do
-    [applications: [:plug],
-     included_applications: [:combine, :inet_cidr]]
+    [
+      app: :remote_ip,
+      version: "0.1.4",
+      elixir: "~> 1.3",
+      package: package(),
+      description: description(),
+      deps: deps(),
+      docs: [source_url: "https://github.com/ajvondrak/remote_ip"]
+    ]
   end
 
   defp description do
     "A plug to overwrite the Conn's remote_ip based on headers such as " <>
-    "X-Forwarded-For."
+      "X-Forwarded-For."
   end
 
   defp package do
-    %{files: ~w[lib mix.exs README.md LICENSE],
+    %{
+      files: ~w[lib mix.exs README.md LICENSE],
       maintainers: ["Alex Vondrak"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/ajvondrak/remote_ip"}}
+      links: %{"GitHub" => "https://github.com/ajvondrak/remote_ip"}
+    }
   end
 
   defp deps do
-    [{:combine, "~> 0.10"},
-     {:plug, "~> 1.2"},
-     {:inet_cidr, "~> 1.0"},
-     {:ex_doc, "~> 0.14", only: :dev}]
+    [
+      {:combine, "~> 0.10"},
+      {:plug, "~> 1.2"},
+      {:inet_cidr, "~> 1.0"},
+      {:ex_doc, "~> 0.14", only: :dev}
+    ]
   end
 end


### PR DESCRIPTION
Without this, we get an error: 
```sh
** (Mix) Undefined applications: [inet_cidr]
```